### PR TITLE
Fix double nested lambda in getWithTimeout

### DIFF
--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -281,9 +281,8 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
     @Override
     protected void containerIsStarted(InspectContainerResponse containerInfo) {
         driver = Unreliables.retryUntilSuccess(30, TimeUnit.SECONDS,
-                Timeouts.getWithTimeout(10, TimeUnit.SECONDS,
-                        () ->
-                            () -> new RemoteWebDriver(getSeleniumAddress(), capabilities)));
+                () -> Timeouts.getWithTimeout(10, TimeUnit.SECONDS,
+                        () -> new RemoteWebDriver(getSeleniumAddress(), capabilities)));
 
         if (vncRecordingContainer != null) {
             LOGGER.debug("Starting VNC recording");


### PR DESCRIPTION
This fixes #4469, getWithTimeout did only apply to the outer lambda, which returned immediately (the inner lambda). Instead wrap getWithTimeout itself inside a lambda.